### PR TITLE
Initialization list in constexpr constructors and cstring

### DIFF
--- a/JDTools/JD-08.hpp
+++ b/JDTools/JD-08.hpp
@@ -218,7 +218,7 @@ struct ToneVSTPrecomputed
 			tvaToLFO;
 		std::array<uint8_t, 34> unknown;
 	};
-
+	
 	struct LFOs
 	{
 		ToneVSTPrecomputed::LFO lfo1;  // 936, 1040, 1144, 1248
@@ -552,6 +552,5 @@ struct PatchVST
 
 	std::array<char, 20320> empty;  // Surely we will need patches to be able to grow to ten times their current size in the future!
 
-	// static constexpr ZenHeader DEFAULT_ZEN_HEADER = { 3, 5, 0, 100, {0, 0, 0, 0, 0, 0, 0, 0} };
 	static constexpr ZenHeader DEFAULT_ZEN_HEADER = { 3, 5, 0, 100, {} };
 };

--- a/JDTools/JD-08.hpp
+++ b/JDTools/JD-08.hpp
@@ -218,7 +218,7 @@ struct ToneVSTPrecomputed
 			tvaToLFO;
 		std::array<uint8_t, 34> unknown;
 	};
-	
+
 	struct LFOs
 	{
 		ToneVSTPrecomputed::LFO lfo1;  // 936, 1040, 1144, 1248
@@ -552,5 +552,6 @@ struct PatchVST
 
 	std::array<char, 20320> empty;  // Surely we will need patches to be able to grow to ten times their current size in the future!
 
+	// static constexpr ZenHeader DEFAULT_ZEN_HEADER = { 3, 5, 0, 100, {0, 0, 0, 0, 0, 0, 0, 0} };
 	static constexpr ZenHeader DEFAULT_ZEN_HEADER = { 3, 5, 0, 100, {} };
 };

--- a/JDTools/Utils.hpp
+++ b/JDTools/Utils.hpp
@@ -13,7 +13,9 @@ struct uint16le
 {
 	uint8_t lsb, msb;
 
-	constexpr uint16le(const uint16_t value = 0) noexcept : lsb(static_cast<uint8_t>(value)), msb(static_cast<uint8_t>(value >> 8))
+	constexpr uint16le(const uint16_t value = 0) noexcept
+		: lsb{static_cast<uint8_t>(value)}
+		, msb{static_cast<uint8_t>(value >> 8)}
 	{
 	}
 

--- a/JDTools/Utils.hpp
+++ b/JDTools/Utils.hpp
@@ -7,15 +7,14 @@
 #include <array>
 #include <iostream>
 #include <vector>
+#include <cstring>
 
 struct uint16le
 {
 	uint8_t lsb, msb;
 
-	constexpr uint16le(const uint16_t value = 0) noexcept
+	constexpr uint16le(const uint16_t value = 0) noexcept : lsb(static_cast<uint8_t>(value)), msb(static_cast<uint8_t>(value >> 8))
 	{
-		lsb = static_cast<uint8_t>(value);
-		msb = static_cast<uint8_t>(value >> 8);
 	}
 
 	constexpr operator uint16_t() const noexcept
@@ -33,12 +32,8 @@ struct uint32le
 {
 	std::array<uint8_t, 4> bytes;
 
-	constexpr uint32le(const uint32_t value = 0) noexcept
+	constexpr uint32le(const uint32_t value = 0) noexcept : bytes({static_cast<uint8_t>(value), static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value >> 16), static_cast<uint8_t>(value >> 24)})
 	{
-		bytes[0] = static_cast<uint8_t>(value);
-		bytes[1] = static_cast<uint8_t>(value >> 8);
-		bytes[2] = static_cast<uint8_t>(value >> 16);
-		bytes[3] = static_cast<uint8_t>(value >> 24);
 	}
 
 	constexpr operator uint32_t() const noexcept

--- a/JDTools/Utils.hpp
+++ b/JDTools/Utils.hpp
@@ -32,7 +32,8 @@ struct uint32le
 {
 	std::array<uint8_t, 4> bytes;
 
-	constexpr uint32le(const uint32_t value = 0) noexcept : bytes({static_cast<uint8_t>(value), static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value >> 16), static_cast<uint8_t>(value >> 24)})
+	constexpr uint32le(const uint32_t value = 0) noexcept
+		: bytes{{static_cast<uint8_t>(value), static_cast<uint8_t>(value >> 8), static_cast<uint8_t>(value >> 16), static_cast<uint8_t>(value >> 24)}}
 	{
 	}
 


### PR DESCRIPTION
I was having issues with compiling JDTools with g++ 9.4 in Ubuntu 20.04. It didn't accept the constructors for `uint16le` and `uint32le` in `constexpr` expressions, until I changed them to use initializer lists. 

It also did not find `memcmp` in `Utils.hpp`, so I added an include for `<cstring>`. 

With these changes it compiles and appears to be working ok.

Thanks for the great work!